### PR TITLE
Add `libdev-ssl` for Ubuntu hosts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,20 +5,20 @@
 # === Parameters
 #  [*package_ensure*]           openssl package ensure
 #  [*ca_certificates_ensure*]   ca-certificates package ensure
-#  [*libssl_dev_ensure*]        libssl-dev ensure
+#  [*dev_package_ensure*]       dev package ensure (currently only Ubuntu)
 #
 # === Example
 #
 #   class { '::openssl':
 #     package_ensure         => latest,
 #     ca_certificates_ensure => latest,
-#     libssl_dev_ensure      => latest,
+#     dev_package_ensure     => latest,
 #   }
 #
 class openssl (
   $package_ensure         = present,
   $ca_certificates_ensure = present,
-  $libssl_dev_ensure      = present,
+  $dev_package_ensure     = undef,
 ){
   class { '::openssl::packages': } ->
   Class['openssl']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,17 +5,20 @@
 # === Parameters
 #  [*package_ensure*]           openssl package ensure
 #  [*ca_certificates_ensure*]   ca-certificates package ensure
+#  [*libssl_dev_ensure*]        libssl-dev ensure
 #
 # === Example
 #
 #   class { '::openssl':
 #     package_ensure         => latest,
 #     ca_certificates_ensure => latest,
+#     libssl_dev_ensure      => latest,
 #   }
 #
 class openssl (
   $package_ensure         = present,
   $ca_certificates_ensure = present,
+  $libssl_dev_ensure      = present,
 ){
   class { '::openssl::packages': } ->
   Class['openssl']

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -6,9 +6,9 @@ class openssl::packages {
     ensure => $openssl::package_ensure,
   }
 
-  if $::osfamily == 'Debian' {
+  if $openssl::dev_package_ensure && $::osfamily == 'Debian' {
     package { 'libssl-dev':
-      ensure => $openssl::libssl_dev_ensure,
+      ensure => $openssl::dev_package_ensure,
     }
   }
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -6,6 +6,12 @@ class openssl::packages {
     ensure => $openssl::package_ensure,
   }
 
+  if $::osfamily == 'Debian'
+    package { 'libssl-dev':
+      ensure => $openssl::libssl_dev_ensure,
+    }
+  }
+
   if $::osfamily == 'Debian' or (
   $::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '6.0') >= 0) {
     ensure_packages(['ca-certificates'], {

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -6,7 +6,7 @@ class openssl::packages {
     ensure => $openssl::package_ensure,
   }
 
-  if $::osfamily == 'Debian'
+  if $::osfamily == 'Debian' {
     package { 'libssl-dev':
       ensure => $openssl::libssl_dev_ensure,
     }


### PR DESCRIPTION
Update the `openssl` manifest to include the `libdev-ssl` package when
installing on Ubuntu hosts so that anything relying on the development packages
available.
